### PR TITLE
fix go.mod (go version 1.12 -> 1.11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knightso/goslides
 
-go 1.12
+go 1.11
 
 require (
 	golang.org/x/sync v0.0.0-20190412183630-56d357773e84 // indirect


### PR DESCRIPTION
go.mod のバージョンを 1.11 に修正しました。